### PR TITLE
adafruit_pio_uart.receive() should return None on no bytes received

### DIFF
--- a/adafruit_pio_uart.py
+++ b/adafruit_pio_uart.py
@@ -184,6 +184,8 @@ class UART:
         else:
             buf = bytearray(n)
         n = self.readinto(buf)
+        if n == 0:
+            return None
         if n < len(buf):
             return buf[:n]
         return buf


### PR DESCRIPTION
To match `busio.UART.receive()`, `adafruit_pio_uart.receive()` should return `None` when no bytes are received.

E.g. This code below should print nothing until bytes are received. Currently it prints continuously because `receive()` returns an empty list. 

```py
import time
import board, busio
import adafruit_pio_uart
uart = adafruit_pio_uart.UART(tx=None, rx=board.SCL1, baudrate=31250, timeout=0.001)
while True:
    data = uart.read(3)  # read up to 3 bytes
    if data is not None:
        print("data:", ["%02x" % x for x in data])
```