### PR TITLE
readinto can also return None

### DIFF
--- a/adafruit_pio_uart.py
+++ b/adafruit_pio_uart.py
@@ -184,7 +184,7 @@ class UART:
         else:
             buf = bytearray(n)
         n = self.readinto(buf)
-        if n == 0:
+        if n == 0 or n is None:
             return None
         if n < len(buf):
             return buf[:n]


### PR DESCRIPTION
When timeout=0 "n = self.readinto(buf)" can return None which results in an error at "if n < ...".

TypeError: unsupported types for __lt__: 'NoneType', 'int'