### PR TITLE
Add support for hardware flow control.

### DIFF
--- a/adafruit_pio_uart.py
+++ b/adafruit_pio_uart.py
@@ -43,7 +43,7 @@ class UART:
         self._timeout = timeout
         self.rx_pio = None
         if rx:
-            if rts: 
+            if rts:
                 # Fleshed-out 8n1 UART receiver with hardware flow control handling
                 # framing errors and break conditions more gracefully.
                 # Wait for the start bit whilst updating rts with the FIFO level

--- a/adafruit_pio_uart.py
+++ b/adafruit_pio_uart.py
@@ -43,7 +43,7 @@ class UART:
         self._timeout = timeout
         self.rx_pio = None
         if rx:
-            if rts:    
+            if rts: 
                 # Fleshed-out 8n1 UART receiver with hardware flow control handling
                 # framing errors and break conditions more gracefully.
                 # Wait for the start bit whilst updating rts with the FIFO level
@@ -87,7 +87,7 @@ class UART:
                     auto_push=False,
                     push_threshold=self.bitcount,
                     first_out_pin=rts,
-                    mov_status_type='rxfifo',
+                    mov_status_type="rxfifo",
                     mov_status_n=7,
                 )
             else:
@@ -137,7 +137,7 @@ class UART:
 
                 # Line by line explanation:
                 # * Assert stop bit, or stall with line in idle state
-                # * Wait for CTS# before transmitting 
+                # * Wait for CTS# before transmitting
                 # * Preload bit counter, assert start bit for 8 clocks
                 # * This loop will run 8 times (8n1 UART)
                 # * Shift 1 bit from OSR to the first OUT pin

--- a/adafruit_pio_uart.py
+++ b/adafruit_pio_uart.py
@@ -33,7 +33,16 @@ class UART:
     Parity = busio.UART.Parity
 
     def __init__(
-        self, tx=None, rx=None, baudrate=9600, bits=8, parity=None, stop=1, timeout=1, cts=None, rts=None
+        self,
+        tx=None,
+        rx=None,
+        baudrate=9600,
+        bits=8,
+        parity=None,
+        stop=1,
+        timeout=1,
+        cts=None,
+        rts=None,
     ):  # pylint: disable=invalid-name, too-many-arguments
         self.bitcount = bits + (1 if parity else 0)
         self.bits = bits


### PR DESCRIPTION
I've tested it with flow control enabled against itself on another Pico, the hardware UART on another Pico and an FTDI breakout (which sometimes sends 2 bytes after RTS# is taken high).

I've also updated the "line by line" description to more match the PIO code as it looks like it was originally written against code based on the "uart_rx_mini" example.